### PR TITLE
Button link improv david i6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL=http://127.0.0.1:5500/source/Login/Login.html" />
+<meta http-equiv="refresh" content="0; URL=https://cse112-sp22-teamxrefactor.github.io/CSE112-SP22-TeamXRefactor/source/Login/Login.html" />

--- a/source/DailyOverview/DailyStyles.css
+++ b/source/DailyOverview/DailyStyles.css
@@ -291,4 +291,5 @@ button#right {
     background-color: var(--bg-color);
     border: none;
     border-radius: 0.5vh;
+    cursor: pointer;
 }

--- a/source/DailyOverview/bullet.js
+++ b/source/DailyOverview/bullet.js
@@ -68,6 +68,7 @@ class BulletEntry extends HTMLElement {
                     background-color: #e4e4e4;
                     border: none;
                     border-radius: 0.5vh;
+                    cursor: pointer;
                 }
                 #features {
                     width: 100%;

--- a/source/Index/IndexStyles.css
+++ b/source/Index/IndexStyles.css
@@ -286,3 +286,4 @@ ul {
     padding: 0.3vh;
     cursor: pointer;
 }
+

--- a/source/Index/IndexStyles.css
+++ b/source/Index/IndexStyles.css
@@ -116,6 +116,9 @@ Structure
     display: block;
     width: 70%;
 }
+#today-button:hover {
+    text-decoration: underline;
+}
 
 button {
     background-color: var(--bg-color);
@@ -281,4 +284,5 @@ ul {
     border-radius: 0.8vw;
     font-size: 1vw;
     padding: 0.3vh;
+    cursor: pointer;
 }

--- a/source/Index/IndexStyles.css
+++ b/source/Index/IndexStyles.css
@@ -145,7 +145,7 @@ button:hover {
 #content .yearlink:hover {
     -color: var(--bg-color);
     text-decoration: underline;
-    text-decoration-color: var(--bg-color);
+    text-decoration-color: black;
     text-decoration-thickness: 3px;
 }
 

--- a/source/Login/LoginStyles.css
+++ b/source/Login/LoginStyles.css
@@ -56,6 +56,11 @@ body {
     font-size: 5vh;
     margin: 0.5% 1vw;
     height: 20%;
+    cursor: pointer;
+    text-decoration: none;
+}
+#login-button:hover {
+    text-decoration: underline;
 }
 
 input {

--- a/source/MonthlyOverview/MonthlyStyles.css
+++ b/source/MonthlyOverview/MonthlyStyles.css
@@ -128,6 +128,7 @@ body {
     background-color: var(--bg-color);
     border: none;
     border-radius: 0.5vh;
+    cursor: pointer;
 }
 
 #goals::-webkit-scrollbar {

--- a/source/MonthlyOverview/goals.js
+++ b/source/MonthlyOverview/goals.js
@@ -66,6 +66,7 @@ class GoalsEntry extends HTMLElement {
                     background-color: #e4e4e4;
                     border: none;
                     border-radius: 0.5vh;
+                    cursor:pointer;
                 }
             </style>
             <article class="bullet">

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -119,28 +119,28 @@ function renderGoals(goals) {
 }
 
 /**kk */
-//link the months
-document.getElementById('January').children[0].href =
+//link the months; the 'a' tag is the parent now so you can just search by the ids
+document.getElementById('January').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#01/' + currentYear;
-document.getElementById('February').children[0].href =
+document.getElementById('February').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#02/' + currentYear;
-document.getElementById('March').children[0].href =
+document.getElementById('March').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#03/' + currentYear;
-document.getElementById('April').children[0].href =
+document.getElementById('April').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#04/' + currentYear;
-document.getElementById('May').children[0].href =
+document.getElementById('May').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#05/' + currentYear;
-document.getElementById('June').children[0].href =
+document.getElementById('June').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#06/' + currentYear;
-document.getElementById('July').children[0].href =
+document.getElementById('July').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#07/' + currentYear;
-document.getElementById('August').children[0].href =
+document.getElementById('August').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#08/' + currentYear;
-document.getElementById('September').children[0].href =
+document.getElementById('September').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#09/' + currentYear;
-document.getElementById('October').children[0].href =
+document.getElementById('October').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#10/' + currentYear;
-document.getElementById('November').children[0].href =
+document.getElementById('November').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#11/' + currentYear;
-document.getElementById('December').children[0].href =
+document.getElementById('December').href =
     '../MonthlyOverview/MonthlyOverview.html' + '#12/' + currentYear;

--- a/source/YearlyOverview/YearlyOverview.html
+++ b/source/YearlyOverview/YearlyOverview.html
@@ -45,22 +45,22 @@
             <div id="monthView">
                 <h1 id="monthHeader">Months</h1>
                 <div id="months">
-                    <h2 id="January">
-                        <a href="../MonthlyOverview/MonthlyOverview.html">
+                    <a id="January" href="../MonthlyOverview/MonthlyOverview.html">
+                        <h2 >
                             January
-                        </a>
-                    </h2>
-                    <h2 id="February"><a href=""> February </a></h2>
-                    <h2 id="March"><a href=""> March </a></h2>
-                    <h2 id="April"><a href=""> April </a></h2>
-                    <h2 id="May"><a href=""> May </a></h2>
-                    <h2 id="June"><a href=""> June </a></h2>
-                    <h2 id="July"><a href=""> July </a></h2>
-                    <h2 id="August"><a href=""> August </a></h2>
-                    <h2 id="September"><a href=""> September </a></h2>
-                    <h2 id="October"><a href=""> October </a></h2>
-                    <h2 id="November"><a href=""> November </a></h2>
-                    <h2 id="December"><a href=""> December </a></h2>
+                        </h2>
+                    </a>
+                    <a id="February"><h2 href=""> February </h2></a>
+                    <a id="March"><h2 href=""> March </h2></a>
+                    <a id="April"><h2 href=""> April </h2></a>
+                    <a id="May"><h2 href=""> May </h2></a>
+                    <a id="June"><h2 href=""> June </h2></a>
+                    <a id="July"><h2 href=""> July </h2></a>
+                    <a id="August"><h2 href=""> August </h2></a>
+                    <a id="September"><h2 href=""> September </h2></a>
+                    <a id="October"><h2 href=""> October </h2></a>
+                    <a id="November"><h2 href=""> November </h2></a>
+                    <a id="December"><h2 href=""> December </h2></a>
                 </div>
             </div>
         </div>

--- a/source/YearlyOverview/YearlyStyles.css
+++ b/source/YearlyOverview/YearlyStyles.css
@@ -105,6 +105,7 @@ body {
     background-color: var(--bg-color);
     border: none;
     border-radius: 0.5vh;
+    cursor: pointer;
 }
 
 #monthView {
@@ -118,11 +119,14 @@ body {
     max-width: 40%;
 }
 
-#months > h2 {
+#months > a {
     font-size: 2.5vh;
 }
+#months > a :hover {
+    text-decoration: underline;
+}
 
-#months > h2 > a {
+#months > a  {
     text-decoration: none;
 }
 
@@ -133,6 +137,7 @@ body {
     overflow: -moz-scrollbars-none;
     /* this will hide the scrollbar in internet explorers */
     -ms-overflow-style: none;
+    
 }
 
 /* this will hide the scrollbar in webkit based browsers - safari, chrome, etc */
@@ -140,9 +145,10 @@ body {
     /* width: 0px; */
     display: none;
 }
-#January,
-#February,
-#March {
+/* have to do first child since the anchor tag is the parent and the h2 tag is the child */
+#January :first-child,
+#February :first-child,
+#March :first-child {
     background: #c2e0f5 url(../Images/BlueDino.svg) no-repeat 5% 30%;
     background-size: 140% 140%;
     margin: 1vw;
@@ -152,9 +158,11 @@ body {
     border-width: 1mm;
     height: 10vh;
 }
-#April,
-#May,
-#June {
+/* have to do first child since the anchor tag is the parent and the h2 tag is the child */
+
+#April :first-child,
+#May :first-child,
+#June :first-child{
     background: #aad6a2 url(../Images/GreenDino.svg) no-repeat 5% 30%;
     background-size: 140% 140%;
     margin: 1vw;
@@ -164,9 +172,11 @@ body {
     border-width: 1mm;
     height: 10vh;
 }
-#July,
-#August,
-#September {
+/* have to do first child since the anchor tag is the parent and the h2 tag is the child */
+
+#July :first-child,
+#August :first-child,
+#September :first-child {
     background: #ffdea2 url(../Images/YellowDino.svg) no-repeat 5% 30%;
     background-size: 140% 140%;
     margin: 1vw;
@@ -176,9 +186,11 @@ body {
     border-width: 1mm;
     height: 10vh;
 }
-#October,
-#November,
-#December {
+/* have to do first child since the anchor tag is the parent and the h2 tag is the child */
+
+#October :first-child,
+#November :first-child,
+#December :first-child{
     background: #fecf94 url(../Images/OrangeDino.svg) no-repeat 5% 30%;
     background-size: 140% 140%;
     margin: 1vw;

--- a/source/YearlyOverview/goals.js
+++ b/source/YearlyOverview/goals.js
@@ -64,6 +64,7 @@ class GoalsEntry extends HTMLElement {
                     background-color: #e4e4e4;
                     border: none;
                     border-radius: 0.5vh;
+                    cursor: pointer;
                 }
             </style>
             <article class="bullet">

--- a/source/tests/PuppTests.test.js
+++ b/source/tests/PuppTests.test.js
@@ -60,13 +60,11 @@ describe('basic navigation for BJ', () => {
         let msg = null;
         page.on('dialog', async (dialog) => {
             await page.waitForTimeout(1000);
-            console.log(dialog.message());
             msg = dialog.message();
             // we set up the alert dialog box dismiss handle here so this line only needs to be here once
             await dialog.dismiss();
         });
         await page.click('#login-button', { clickCount: 1 });
-        console.log(msg);
         expect(msg).toMatch('Please provide a username');
     });
 
@@ -185,7 +183,6 @@ describe('basic navigation for BJ', () => {
             passwordInput.value = '123';
         });
 
-        console.log('here2');
         page.on('dialog', async (dialog) => {
             await page.waitForTimeout(1000);
             msg = dialog.message();
@@ -201,7 +198,6 @@ describe('basic navigation for BJ', () => {
     it('Test6: go to index screen, make sure highlighted day is the current day', async () => {
         await page.goto('http://127.0.0.1:5500/source/Index/Index.html');
         await page.waitForTimeout(300);
-        // console.log("here3")
         const currentDayHigh = await page.$eval('.today', (day) => {
             return day.innerHTML;
         });

--- a/source/tests/PuppTests.test.js
+++ b/source/tests/PuppTests.test.js
@@ -710,7 +710,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test36: navigating through the months should work', async () => {
-        await page.$eval('#' + currentMonth , (button) => {
+        await page.$eval('#' + currentMonth, (button) => {
             button.click();
         });
 
@@ -765,7 +765,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test39: check yearly goals edited in yearly overview', async () => {
-        await page.$eval('#' + currentMonth , (button) => {
+        await page.$eval('#' + currentMonth, (button) => {
             button.click();
         });
 
@@ -801,7 +801,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test41: check yearly goals marked done in daily overview', async () => {
-        await page.$eval('#' + currentMonth , (button) => {
+        await page.$eval('#' + currentMonth, (button) => {
             button.click();
         });
 
@@ -838,7 +838,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test43: check yearly goals removed in daily overview', async () => {
-        await page.$eval('#' + currentMonth , (button) => {
+        await page.$eval('#' + currentMonth, (button) => {
             button.click();
         });
 

--- a/source/tests/PuppTests.test.js
+++ b/source/tests/PuppTests.test.js
@@ -687,7 +687,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test36: navigating through the months should work', async () => {
-        await page.$eval('#May > a', (button) => {
+        await page.$eval('#May', (button) => {
             button.click();
         });
 
@@ -742,7 +742,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test39: check yearly goals edited in yearly overview', async () => {
-        await page.$eval('#May > a', (button) => {
+        await page.$eval('#May', (button) => {
             button.click();
         });
 
@@ -778,7 +778,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test41: check yearly goals marked done in daily overview', async () => {
-        await page.$eval('#May > a', (button) => {
+        await page.$eval('#May', (button) => {
             button.click();
         });
 
@@ -815,7 +815,7 @@ describe('basic navigation for BJ', () => {
     });
 
     it('Test43: check yearly goals removed in daily overview', async () => {
-        await page.$eval('#May > a', (button) => {
+        await page.$eval('#May', (button) => {
             button.click();
         });
 


### PR DESCRIPTION
#6 
NOTE: i did pull the changes that Kathy made to the pupptests file so that the month doesn't matter in the test but with how I made the months in the yearly overview clickable I had to remove the ' > a'.
Main Changes:
On yearly overview, for the months, the whole block is clickable and on hover the month name underlines. What I did was swap the html and adjusted the css. Before the 'a' tag was the child of the h2 tag of each month but now it's swapped so now the whole thing is clickable and the 'a' tag is the parent of the h2 tag.
On login page, on hover the sign in button text underlines and the cursor turns into a pointer.
On the index page, when hovering over each yearly overview link, the underline text is darker since to me the underline is hard to see with the background also being the same color. Also on hover over the "go to the current day", the text underlines
For each overview page, on hover over the post button, the cursor turns into a pointer. Also when goals and todos are inputted on hovering over the 'v' icon dropdown menu, the cursor turns into a pointer
![image](https://user-images.githubusercontent.com/76570554/171337088-ed70c9df-6e77-49e7-b0b4-39f13bedfd02.png)
Add photo test passes as well
![image](https://user-images.githubusercontent.com/76570554/171336418-74d26cc9-0008-437c-b92b-018f3105afdb.png)