### PR TITLE
Current year visible david i52

### DIFF
--- a/source/Index/Calendar.js
+++ b/source/Index/Calendar.js
@@ -38,7 +38,8 @@ function setupContent() {
         //
         //wrapper
         let year_wrapper = document.createElement('div');
-        year_wrapper.id = yr;
+        // I added year_ because id's shoud start with a letter
+        year_wrapper.id = "year_" + yr;
         //
         //button group
         let year_nav = document.createElement('div');
@@ -53,7 +54,8 @@ function setupContent() {
         //year link
         let yearlink = document.createElement('a');
         yearlink.classList.add('yearlink');
-        yearlink.id = yr + '_link';
+        // I added year_ because id's shoud start with a letter
+        yearlink.id = "year_" + yr + '_link';
         //yearlink.href = '/year/' + yr + '.html';
         yearlink.href = year_OV_link + '#' + yr;
         yearlink.innerText = yr + ' Yearly Overview';

--- a/source/Index/IndexJS.js
+++ b/source/Index/IndexJS.js
@@ -3,7 +3,6 @@ let collapsible_years_list = document.getElementsByClassName('coll_yr_button');
 window.addEventListener('load', () => {
     //gets the session, if the user isn't logged in, sends them to login page
     let session = window.sessionStorage;
-    console.log('here is storage session', session);
     if (session.getItem('loggedIn') !== 'true') {
         window.location.href = '../Login/Login.html';
     }
@@ -11,14 +10,12 @@ window.addEventListener('load', () => {
     // eslint-disable-next-line no-undef
     let dbPromise = initDB();
     dbPromise.onsuccess = function (e) {
-        console.log('database connected');
         // eslint-disable-next-line no-undef
         setDB(e.target.result);
         // eslint-disable-next-line no-undef
         let req = getSettings();
         req.onsuccess = function (e) {
             let settingObj = e.target.result;
-            console.log('setting initial theme');
             document.documentElement.style.setProperty(
                 '--bg-color',
                 settingObj.theme

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -27,7 +27,6 @@ document.getElementById('header').insertBefore(currentYearTag, houseIcon);
 window.addEventListener('load', () => {
     //gets the session, if the user isn't logged in, sends them to login page
     let session = window.sessionStorage;
-    console.log('here is storage session', session);
     if (session.getItem('loggedIn') !== 'true') {
         window.location.href = '../Login/Login.html';
     }
@@ -74,8 +73,6 @@ document.querySelector('.entry-form').addEventListener('submit', (submit) => {
 
 // lets bullet component listen to when a bullet is deleted
 document.querySelector('#bullets').addEventListener('deleted', function (e) {
-    console.log('got event');
-    console.log(e.composedPath());
     let index = e.composedPath()[0].getAttribute('index');
     currentYearRes.goals.splice(index, 1);
     updateYearsGoals(currentYearRes);
@@ -85,8 +82,6 @@ document.querySelector('#bullets').addEventListener('deleted', function (e) {
 
 // lets bullet component listen to when a bullet is edited
 document.querySelector('#bullets').addEventListener('edited', function (e) {
-    console.log('got event');
-    console.log(e.composedPath()[0]);
     let newText = JSON.parse(e.composedPath()[0].getAttribute('goalJson')).text;
     let index = e.composedPath()[0].getAttribute('index');
     currentYearRes.goals[index].text = newText;
@@ -97,8 +92,6 @@ document.querySelector('#bullets').addEventListener('edited', function (e) {
 
 // lets bullet component listen to when a bullet is marked done
 document.querySelector('#bullets').addEventListener('done', function (e) {
-    console.log('got done event');
-    console.log(e.composedPath()[0]);
     let index = e.composedPath()[0].getAttribute('index');
     currentYearRes.goals[index].done ^= true;
     updateYearsGoals(currentYearRes);
@@ -116,7 +109,6 @@ function renderGoals(goals) {
         newPost.setAttribute('goalJson', JSON.stringify(goal));
         newPost.setAttribute('index', i);
         newPost.entry = goal;
-        console.log(newPost);
         document.querySelector('#bullets').appendChild(newPost);
         i++;
     });

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -17,12 +17,12 @@ console.log(currentYear);
 let currentYearRes;
 
 // add the current year to the page so the user can tell what yearly overview they are on
-let currentYearTag = document.createElement("h2")
-console.log(currentYearTag)
-currentYearTag.innerHTML = currentYear
-currentYearTag.id = "currentYear"
-let houseIcon = document.getElementById("house")
-document.getElementById("header").insertBefore(currentYearTag, houseIcon)
+let currentYearTag = document.createElement('h2');
+console.log(currentYearTag);
+currentYearTag.innerHTML = currentYear;
+currentYearTag.id = 'currentYear';
+let houseIcon = document.getElementById('house');
+document.getElementById('header').insertBefore(currentYearTag, houseIcon);
 
 window.addEventListener('load', () => {
     //gets the session, if the user isn't logged in, sends them to login page

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -33,12 +33,9 @@ window.addEventListener('load', () => {
     }
     let dbPromise = initDB();
     dbPromise.onsuccess = function (e) {
-        console.log('database connected');
         setDB(e.target.result);
         let req = getYearlyGoals(currentYear);
         req.onsuccess = function (e) {
-            console.log('got year');
-            console.log(e.target.result);
             currentYearRes = e.target.result;
             if (currentYearRes === undefined) {
                 currentYearRes = initYear(currentYear);
@@ -52,7 +49,6 @@ window.addEventListener('load', () => {
         let settingsReq = getSettings();
         settingsReq.onsuccess = function (e) {
             let settingObj = e.target.result;
-            console.log('setting initial theme');
             document.documentElement.style.setProperty(
                 '--bg-color',
                 settingObj.theme

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -16,6 +16,14 @@ console.log(currentYear);
 // contains the current year's yearlyGoal object from the database
 let currentYearRes;
 
+// add the current year to the page so the user can tell what yearly overview they are on
+let currentYearTag = document.createElement("h2")
+console.log(currentYearTag)
+currentYearTag.innerHTML = currentYear
+currentYearTag.id = "currentYear"
+let houseIcon = document.getElementById("house")
+document.getElementById("header").insertBefore(currentYearTag, houseIcon)
+
 window.addEventListener('load', () => {
     //gets the session, if the user isn't logged in, sends them to login page
     let session = window.sessionStorage;

--- a/source/YearlyOverview/YearlyJS.js
+++ b/source/YearlyOverview/YearlyJS.js
@@ -11,17 +11,17 @@ let currentYear = myLocation.substring(
 if (currentYear == 'html') {
     currentYear = 2021;
 }
-console.log(currentYear);
 // currentYear = '2020';
 // contains the current year's yearlyGoal object from the database
 let currentYearRes;
 
 // add the current year to the page so the user can tell what yearly overview they are on
 let currentYearTag = document.createElement('h2');
-console.log(currentYearTag);
-currentYearTag.innerHTML = currentYear;
+currentYearTag.innerHTML = `${currentYear} Yearly Overview`;
 currentYearTag.id = 'currentYear';
 let houseIcon = document.getElementById('house');
+// this line gets the element header which is the parent of the houseIcon and then puts
+// the current year before the houseIcon in the html
 document.getElementById('header').insertBefore(currentYearTag, houseIcon);
 
 window.addEventListener('load', () => {

--- a/source/YearlyOverview/YearlyStyles.css
+++ b/source/YearlyOverview/YearlyStyles.css
@@ -26,7 +26,7 @@ body {
     display: grid;
     margin: 1vh;
 
-    grid-template-areas: 'back . . .  . headerHome';
+    grid-template-areas: 'back . currentYear  . headerHome';
 }
 
 #house {
@@ -63,6 +63,14 @@ body {
     flex-direction: row;
     justify-items: stretch;
     justify-content: space-evenly;
+}
+/* this is the current year of the yearly overview so the user can see what year they are on */
+#currentYear {
+    text-align: center;
+    display: flex;
+    justify-self: center;
+    grid-area: currentYear;
+    font-size: 5vh;
 }
 
 #goalSection {

--- a/source/YearlyOverview/YearlyStyles.css
+++ b/source/YearlyOverview/YearlyStyles.css
@@ -71,6 +71,7 @@ body {
     justify-self: center;
     grid-area: currentYear;
     font-size: 5vh;
+    color: rgb(41, 38, 38);
 }
 
 #goalSection {

--- a/source/tests/currentYearTest.test.js
+++ b/source/tests/currentYearTest.test.js
@@ -3,16 +3,6 @@ const puppeteer = require('puppeteer');
 // please read through some of the comments with NOTE: if this test fails
 // This test is more for local testing since I am not sure what would happen to the test if it is run on github
 let date = new Date();
-const YEARS = [
-    '2018',
-    '2019',
-    '2020',
-    '2021',
-    '2022',
-    '2023',
-    '2024',
-    '2025'
-];
 let currentYear = date.getFullYear();
 
 describe('basic navigation for BJ', () => {

--- a/source/tests/currentYearTest.test.js
+++ b/source/tests/currentYearTest.test.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-undef*/
+const puppeteer = require('puppeteer');
+// please read through some of the comments with NOTE: if this test fails
+// This test is more for local testing since I am not sure what would happen to the test if it is run on github
+let date = new Date();
+const YEARS = [
+    '2018',
+    '2019',
+    '2020',
+    '2021',
+    '2022',
+    '2023',
+    '2024',
+    '2025'
+];
+let currentYear = date.getFullYear();
+
+describe('basic navigation for BJ', () => {
+    it('Test1: Login, go to current yearly overview and check the current year is displayed right ', async (done) => {
+        jest.setTimeout(90000);
+        const browser = await puppeteer.launch({
+            headless: false,
+            slowMo: 250,
+        });
+        const page = await browser.newPage();
+        // this lets us see console.logs in this format : await page.evaluate(() => console.log());
+        page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+        console.log(typeof(currentYear))
+        // NOTE: use this link for when our changes are pushed to the master branch
+        // await page.goto(
+        //     'https://cse112-sp22-teamxrefactor.github.io/CSE112-SP22-TeamXRefactor/source/Login/Login.html'
+        // );
+        // NOTE: for local testing depending on what URL live server takes you, you will need to change this
+        await page.goto('http://127.0.0.1:5500/source/Login/Login.html');
+
+        await page.waitForTimeout(500);
+
+        // login page check
+        const headerText = await page.$eval('#title', (header) => {
+            return header.innerHTML;
+        });
+        expect(headerText).toBe('Create your login!');
+
+        // login now
+        await page.$eval('#username', (usernameInput) => {
+            usernameInput.value = 'SampleUsername';
+        });
+
+        await page.$eval('#pin', (passwordInput) => {
+            passwordInput.value = '1234';
+        });
+        await page.waitForTimeout(300);
+
+        page.on('dialog', async (dialog) => {
+            await dialog.dismiss();
+        });
+
+        await page.$eval('#login-button', (button) => {
+            button.click();
+        });
+        /**
+         * for some reason, the css selectors don't like underscores or ids beginning with numbers
+         * have to manually traverse through the children to find the correct year
+         * namning mistake
+         * Just going to use 2021 as an example
+         */
+        await page.$eval(`${currentYear}`, (currentYearDiv ) => {
+            
+            console.log(currentYearDiv)
+        })
+
+        const year = await page.$eval("#currentYear", (header) => {
+            return header.innerHTML
+        })
+        expect(year).toBe(currentYear + "yearly overview")
+        done();
+        await page.waitForTimeout(3000);
+        browser.close();
+    });
+});

--- a/source/tests/currentYearTest.test.js
+++ b/source/tests/currentYearTest.test.js
@@ -24,8 +24,7 @@ describe('basic navigation for BJ', () => {
         });
         const page = await browser.newPage();
         // this lets us see console.logs in this format : await page.evaluate(() => console.log());
-        page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
-        console.log(typeof(currentYear))
+        // page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
         // NOTE: use this link for when our changes are pushed to the master branch
         // await page.goto(
         //     'https://cse112-sp22-teamxrefactor.github.io/CSE112-SP22-TeamXRefactor/source/Login/Login.html'
@@ -58,21 +57,16 @@ describe('basic navigation for BJ', () => {
         await page.$eval('#login-button', (button) => {
             button.click();
         });
-        /**
-         * for some reason, the css selectors don't like underscores or ids beginning with numbers
-         * have to manually traverse through the children to find the correct year
-         * namning mistake
-         * Just going to use 2021 as an example
-         */
-        await page.$eval(`${currentYear}`, (currentYearDiv ) => {
-            
-            console.log(currentYearDiv)
+        
+        let currYearString = currentYear.toString()
+        await page.$eval("#year_" + currYearString + "_link", (anchor) => {
+            anchor.click()
         })
 
         const year = await page.$eval("#currentYear", (header) => {
             return header.innerHTML
         })
-        expect(year).toBe(currentYear + "yearly overview")
+        expect(year).toBe(currentYear + " Yearly Overview")
         done();
         await page.waitForTimeout(3000);
         browser.close();


### PR DESCRIPTION
#52 
What i've done:
- I made a test file to quickly check that the text on the yearly overview shows up right : currentYearTest.test.js. It's not robust, it only checks that if you click on the current year's yearly overview then it should have the right text. I haven't tested for all the other years since I didn't know if we were going to change that.
- I made the text of yearly overview basically black so it would be easier to see
- For each yearly overview, the text "(current year) Yearly Overview" is displayed at the top. This is done in YearlyJS.js
- in IndexJS.js, I changed the id's of two of the elements so that they start with "year_" since id's should only start with a letter
Test for the feature
![image](https://user-images.githubusercontent.com/76570554/171525678-1127a7b0-99d2-46e8-8df4-f545d17098bd.png)
Test for addPhotoTest
![image](https://user-images.githubusercontent.com/76570554/171525785-8323a1f7-3146-4c34-9e71-8b7ec30493c5.png)
Passed tests in PuppTests
![image](https://user-images.githubusercontent.com/76570554/171525903-360245a7-df79-4e02-8aa3-8909a7725a85.png)

